### PR TITLE
fix: add packages write permission

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ env:
 permissions:
   contents: read
   id-token: write
+  packages: write
 
 jobs:
   build:


### PR DESCRIPTION
Required to push container images to the GitHub Container Registry

Closes #6
