### PR TITLE
docs: explain linux-libc-dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ This image is also available as [`containerbase/sidecar`](https://hub.docker.com
 
 This image is used as the default "sidecar" image for Renovate when it uses `binarySource=docker`.
 It is intended that all Containerbase tools are "prepared" with their prerequisites installated into this image so that installation can be done at runtime without root privileges.
+
+## Build dependencies
+
+`prepare-tool all` also prepares Conan, whose compiler toolchain includes `gcc` and `g++`.
+On Ubuntu, the C++ development packages depend on `libc6-dev`, which in turn depends on `linux-libc-dev`.
+The kernel userspace headers are therefore an intentional part of this image; removing them would leave the prepared Conan compiler toolchain with broken package dependencies.


### PR DESCRIPTION
## Summary

- document why `prepare-tool all` retains `linux-libc-dev`
- identify the Conan C++ toolchain dependency chain
- clarify that purging the package would break the prepared compiler package dependencies

## Investigation

`prepare-tool all` includes `ConanPrepareService`, which installs `gcc` and `g++`. On Ubuntu, `g++` pulls the C++ development packages, `libstdc++-13-dev` depends on `libc6-dev`, and `libc6-dev` depends on `linux-libc-dev`. The package is therefore required by the image contract rather than an orphaned build dependency.

## Validation

- `pnpm prettier`
- `git diff --check`

Closes #1525